### PR TITLE
chore: Do not block instrumentation for mongodb driver v5.x

### DIFF
--- a/lib/instrumentation/modules/mongodb.js
+++ b/lib/instrumentation/modules/mongodb.js
@@ -17,7 +17,7 @@ const HOSTNAME_PORT_RE = /^(.+):(\d+)$/
 
 module.exports = (mongodb, agent, { version, enabled }) => {
   if (!enabled) return mongodb
-  if (!semver.satisfies(version, '>=3.3 <5.0')) {
+  if (!semver.satisfies(version, '>=3.3 <6.0')) {
     agent.logger.debug('mongodb version %s not instrumented (mongodb <3.3 is instrumented via mongodb-core)', version)
     return mongodb
   }


### PR DESCRIPTION
Looks like instrumentation for mongodb driver v5.x just work.

<!--

Replace this comment with a description of what's being changed by this PR.

If this PR should close an issue, please add one of the magic keywords
(e.g. Fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

-->

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
